### PR TITLE
Improve Ubuntu version detection (and prepare for imminent switch to 20.04 by default)

### DIFF
--- a/src/download.ts
+++ b/src/download.ts
@@ -21,12 +21,19 @@ function getRunner(): string {
         case "darwin":
             return "macos-10.15";
         case "linux":
-            // TODO: Is there better way to determine Actions runner OS?
-            if (os.release().startsWith("4.15")) {
-                return "ubuntu-16.04";
-            } else {
-                return "ubuntu-18.04";
+            for (const line of require("fs")
+                .readFileSync("/etc/os-release", {
+                    encoding: "utf8",
+                })
+                .split("\n")) {
+                if (line.startsWith("VERSION_ID=")) {
+                    return (
+                        "ubuntu-" + line.substring(10).replaceAll(/["']/g, "")
+                    );
+                }
             }
+
+            throw new Error("Unrecognized version of Ubuntu");
         default:
             throw new Error("Unsupported OS");
     }


### PR DESCRIPTION
This PR makes the `getRunner()` function check `/etc/os-release` to determine the Ubuntu version, rather than hardcoding a kernel version check.

This is also important because the current implementation only checks for Ubuntu 16.04/18.04. Ubuntu 20.04 has been available for use in GitHub Actions for some time, and `ubuntu-latest` will soon default to `ubuntu-20.04` (see actions/virtual-environments#1816).

(Edit: I don't write much Node, and I've never written TypeScript, so I'm happy to make changes to this.)